### PR TITLE
Fix TF broadcasting for the detected AprilTags

### DIFF
--- a/isaac_ros_apriltag/include/isaac_ros_apriltag/apriltag_node.hpp
+++ b/isaac_ros_apriltag/include/isaac_ros_apriltag/apriltag_node.hpp
@@ -81,9 +81,11 @@ private:
   message_filters::Synchronizer<ExactPolicy> camera_image_sync_;
 
   // Publishers
-  const rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_pub_;
   const rclcpp::Publisher<isaac_ros_apriltag_interfaces::msg::AprilTagDetectionArray>::SharedPtr
     detections_pub_;
+
+  // TF broadcaster
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   struct CUAprilTagImpl;
   struct VPIAprilTagImpl;

--- a/isaac_ros_apriltag/src/apriltag_node.cpp
+++ b/isaac_ros_apriltag/src/apriltag_node.cpp
@@ -353,7 +353,7 @@ struct AprilTagNode::VPIAprilTagImpl : AprilTagNode::AprilTagImpl
     }
 
     node.detections_pub_->publish(msg_detections);
-    node.tf_pub_->publish(tfs);
+    node.tf_broadcaster_->sendTransform(tfs.transforms);
 
     // Cleanup
     CHECK_STATUS(vpiArrayUnlock(detections_pose_array));
@@ -532,7 +532,7 @@ struct AprilTagNode::CUAprilTagImpl : AprilTagNode::AprilTagImpl
     }
 
     node.detections_pub_->publish(msg_detections);
-    node.tf_pub_->publish(tfs);
+    node.tf_broadcaster_->sendTransform(tfs.transforms);
   }
 
   ~CUAprilTagImpl()
@@ -555,7 +555,6 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions & options)
   image_sub_{},
   camera_info_sub_{},
   camera_image_sync_{ExactPolicy{3}, image_sub_, camera_info_sub_},
-  tf_pub_(create_publisher<tf2_msgs::msg::TFMessage>("tf", rclcpp::QoS(100))),
   detections_pub_{create_publisher<isaac_ros_apriltag_interfaces::msg::AprilTagDetectionArray>(
       "tag_detections", rclcpp::QoS(1))}
 {
@@ -582,6 +581,9 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions & options)
     RCLCPP_FATAL(get_logger(), os.str().c_str());
     throw std::runtime_error(os.str());
   }
+
+  // Create the TF broadcaster
+  tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(this);
 
   // Setup subscripts
   camera_image_sync_.registerCallback(


### PR DESCRIPTION
Replace
`const rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_pub_;`
by
`std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;`

For a correct TF broadcasting.

Using a standard publisher instead of `tf2_ros::TransformBroadcaster` caused the TF message to not work correctly if the AprilTag node was placed under a namespace, and in any case, it's not the "ROS way" for broadcasting TFs.

<img width="1920" height="1053" alt="image" src="https://github.com/user-attachments/assets/4943991e-aabe-4f82-892c-676c3dc0ff12" />
